### PR TITLE
Check log level before logging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,10 @@ impl log::Log for EventLog {
     }
 
     fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+
         let (ty, id) = match record.level() {
             Level::Error => (EVENTLOG_ERROR_TYPE, MSG_ERROR),
             Level::Warn => (EVENTLOG_WARNING_TYPE, MSG_WARNING),


### PR DESCRIPTION
Apparently `log()` is responsible for checking the log level before logging. This is also in the example at https://docs.rs/log/0.4.14/log/index.html