### PR TITLE
Add Debug to make compatible with log4rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,3 +139,11 @@ impl log::Log for EventLog {
 
     fn flush(&self) {}
 }
+
+impl std::fmt::Debug for EventLog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Windows Event Logger (")?;
+        self.level.fmt(f)?;
+        f.write_str(")")
+    }
+}


### PR DESCRIPTION
Add an implementation for Debug to make EventLog compatible with Append of log4rs: https://docs.rs/log4rs/latest/log4rs/append/trait.Append.html#impl-Append-for-T
This would allow for EventLog to be used just like the other appenders in log4rs.