### PR TITLE
Fix dwdatasize being set as if it was wnumstrings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ impl log::Log for EventLog {
                 0,
                 id,
                 None,
-                vec.len() as u32,
+                0,
                 Some(&vec),
                 None,
             );


### PR DESCRIPTION
fixes #8 

The windows-rs EventLog API doesn't require setting the message buffer size. Attempting to set the missing positional argument means we set `dwdatasize` instead, which should actually always be 0. The E2E tests pass now.